### PR TITLE
ESM/CJS support and type correction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import useErrorCause from "./rules/use-error-cause/use-error-cause";
 type RuleKey = keyof typeof rules;
 
 interface Plugin extends Omit<ESLint.Plugin, "rules"> {
-  rules: Record<RuleKey, RuleModule<string>>;
+  rules: Record<string, RuleDefinition<RuleDefinitionTypeOptions>>;
 }
 
 export const name = "eslint-plugin-exception-handling";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import useErrorCause from "./rules/use-error-cause/use-error-cause";
 type RuleKey = keyof typeof rules;
 
 interface Plugin extends Omit<ESLint.Plugin, "rules"> {
-  rules: Record<string, RuleDefinition<RuleDefinitionTypeOptions>>;
+  rules: Record<string, RuleModule>;
 }
 
 export const name = "eslint-plugin-exception-handling";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,6 @@ import noUnhandled from "./rules/no-unhandled/no-unhandled";
 import mightThrow from "./rules/might-throw/might-throw";
 import useErrorCause from "./rules/use-error-cause/use-error-cause";
 
-type RuleKey = keyof typeof rules;
-
 interface Plugin extends Omit<ESLint.Plugin, "rules"> {
   rules: Record<string, RuleModule>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,12 @@
-import { RuleModule } from "@typescript-eslint/utils/ts-eslint";
 import { ESLint } from "eslint";
 import { rules } from "./rules";
 import noUnhandled from "./rules/no-unhandled/no-unhandled";
 import mightThrow from "./rules/might-throw/might-throw";
 import useErrorCause from "./rules/use-error-cause/use-error-cause";
 
-interface Plugin extends Omit<ESLint.Plugin, "rules"> {
-  rules: Record<string, RuleModule>;
-}
-
 export const name = "eslint-plugin-exception-handling";
-export const plugin: Plugin = {
+
+export const plugin: ESLint.Plugin = {
   meta: {
     name,
     version: "1.0.0",
@@ -25,7 +21,7 @@ export const plugin: Plugin = {
       },
     },
   },
-  rules,
+  rules: rules as unknown as ESLint.Plugin["rules"],
 };
 
 export { rules };

--- a/src/utils/get-import-declaration.ts
+++ b/src/utils/get-import-declaration.ts
@@ -41,7 +41,25 @@ function resolveTSAlias(tsconfigpath: string, to: string, cwd: string) {
   return to;
 }
 
-const codeExt = [".ts", ".js", ".tsx", ".jsx"];
+const codeExt = [".ts", ".js", ".tsx", ".jsx", ".mjs", ".mjsx", ".mts", ".mtsx",  ".cjs", ".cjsx", ".cts", ".ctsx"];
+const extAlts = {
+    // Base family
+    ".js":   [".jsx", ".ts", ".tsx"],
+    ".jsx":  [".js",  ".tsx", ".ts"],
+    ".ts":   [".tsx", ".js", ".jsx"],
+    ".tsx":  [".ts",  ".jsx", ".js"],
+    // ESM-explicit family (m*)
+    ".mjs":  [".mts", ".mjsx", ".mtsx"],
+    ".mjsx": [".mjs", ".mtsx", ".mts"],
+    ".mts":  [".mtsx", ".mjs", ".mjsx"],
+    ".mtsx": [".mts", ".mjsx", ".mjs"],
+    // CJS-explicit family (c*)
+    ".cjs":  [".cts", ".cjsx", ".ctsx"],
+    ".cjsx": [".cjs", ".ctsx", ".cts"],
+    ".cts":  [".ctsx", ".cjs", ".cjsx"],
+    ".ctsx": [".cts", ".cjsx", ".cjs"],
+};
+
 
 function endsWithAny(str: string, arr: string[]) {
   return arr.some((ext) => str.endsWith(ext));
@@ -92,14 +110,11 @@ export function getImportDeclaration(
   }
 
   if (!existsSync(res)) {
-    if (res.endsWith(".js")) {
-      res = findFileExtension(res.replace(".js", ""), [".jsx", ".ts", ".tsx"]);
-    } else if (res.endsWith(".jsx")) {
-      res = findFileExtension(res.replace(".jsx", ""), [".js", ".tsx", ".ts"]);
-    } else if (res.endsWith(".ts")) {
-      res = findFileExtension(res.replace(".ts", ""), [".tsx", ".js", ".jsx"]);
-    } else if (res.endsWith(".tsx")) {
-      res = findFileExtension(res.replace(".tsx", ""), [".ts", ".jsx", ".js"]);
+    for (const [ext, alternatives] of Object.entries(EXTENSION_ALTERNATIVES)) {
+        if (res.endsWith(ext)) {
+            res = findFileExtension(res.slice(0, -ext.length), alternatives);
+            break;
+        }
     }
   }
 

--- a/src/utils/get-import-declaration.ts
+++ b/src/utils/get-import-declaration.ts
@@ -110,7 +110,7 @@ export function getImportDeclaration(
   }
 
   if (!existsSync(res)) {
-    for (const [ext, alternatives] of Object.entries(EXTENSION_ALTERNATIVES)) {
+    for (const [ext, alternatives] of Object.entries(extAlts)) {
         if (res.endsWith(ext)) {
             res = findFileExtension(res.slice(0, -ext.length), alternatives);
             break;


### PR DESCRIPTION
Hi!

While resolving various IDE highlights in my project I encountered 2 issues in the plugin, and I tried to resolved them. Full disclosure: I did use AI to help locate the issues, since I am not that familiar with Node or ESLint plugins, but I did test the changes manually, and did not encounter any obvious issues. So here are the issues being fixed:

1. The type for `rules` in `Plugin` interface. With the previous `Record<RuleKey, RuleModule<string>>;` I was getting 

<img width="1173" height="1602" alt="image" src="https://github.com/user-attachments/assets/6b05ff5e-1202-4797-a404-3ce755dab5a5" />

error from TypeScript. From what I understand this might have been appropriate type for ESLint before 9, but not now. Simply replaced it with `Record<string, RuleDefinition<RuleDefinitionTypeOptions>>;`, have not noticed any side-effects, and there should not be any.

2. Added support for ESM and CJS file extensions like `mjs`, `mts`, `cjs` and `cts`. Without it the plugin would fail like this

<img width="1629" height="413" alt="image" src="https://github.com/user-attachments/assets/56d7a090-2606-4aa4-9aa2-47bdee398684" />

because it was doubling the extension of the import file, if it was being used with one (`Helper.mts.mts` instead of `Helper.mts`). Instead of multiple `if` branches using a map, and it should be easy to update it in the future, if the need arise. As a bonus this also ensures that the 1st argument in `findFileExtension()` will be just the filename without the extension: `.replace` could affect files with names like `a.js.bcd.js` turning them into `abcd.js` as result, which would cause the same kind of error. Such files are probably unlikely to happen, but better avoid this, if we can.

Let me know if anything is unclear or needs correction.